### PR TITLE
wave_ui.py: added encode('utf-8') to type strings for python3 compati…

### DIFF
--- a/waves/wave_ui.py
+++ b/waves/wave_ui.py
@@ -281,7 +281,7 @@ class WaveWindow(UI):
 
             f=open("depth.dat","wb")
             type="%-20s"%"depth"
-            f.write(type)
+            f.write(type.encode('utf-8'))
             f.write(np.asarray([ny,nx],np.int32))
             f.write(np.asarray(0.,np.float64))
             f.write(np.ascontiguousarray(depth))
@@ -291,7 +291,7 @@ class WaveWindow(UI):
             damping = 1.*(1.-mask)
             damping=np.transpose(damping)
             f=open("damping.dat","wb")
-            f.write(type)
+            f.write(type.encode('utf-8'))
             f.write(np.asarray([ny,nx],np.int32))
             f.write(np.asarray(0.,np.float64))
             f.write(np.ascontiguousarray(damping))


### PR DESCRIPTION
…bility

This fix is required for python 3 compatibility. Python 3 compatibility is required for the docker container. 